### PR TITLE
docs: add session devlog for post publish and security updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ dmypy.json
 # Obsidian
 .obsidian/
 
+# Claude Code runtime state
+.claude/scheduled_tasks.lock
+
 # Firebase cache
 .firebase
 

--- a/devlog/2026-04-22-post-publish-and-security-updates.md
+++ b/devlog/2026-04-22-post-publish-and-security-updates.md
@@ -1,0 +1,70 @@
+# Post Publish and Security Updates — 2026-04-22
+
+## Session Summary
+
+Completed publishing the "Waiting for Permission" blog post (PR #104) with client-requested edits, processed the featured image with new CLI tools (`ipro`/`iname`), resolved two high-severity Dependabot alerts by bumping Pillow to 12.2.0 (PR #105), and cleaned up stale remote branches. All changes deployed to production.
+
+## Work Completed
+
+### Blog Post Publication
+- Processed featured image from ~/Downloads/IMG_4114.JPG (MPO format, iPhone source)
+  - Converted to JPEG with EXIF stripping using `ipro convert --format jpg --quality 80 --strip-exif`
+  - Resized to 720px width at 80% quality with `ipro resize --width 720 --quality 80`
+  - Renamed to `wildflowers-ice-plant-bloom.jpg` using `iname`
+  - Placed in `erlenepsyd.com/content/images/` with `.image-process-crisp` class
+- Added featured image to "Waiting for Permission" post (full-width layout, no `.right` float)
+- Incorporated client feedback from email (2026-04-21):
+  - Changed heading "Wishes We Don't Act On" → "Unfulfilled Wishes"
+  - Converted "wastes time" from a link to `tick-tock.md` into plain italics
+- Merged PR #104 to main; production deployment auto-triggered
+
+### Security Updates
+- Investigated two Dependabot high-severity alerts (GHSA-whj4-6x5x-4v2j) for Pillow
+- Bumped Pillow from 12.1.1 → 12.2.0 across `pyproject.toml`, `poetry.lock`, `requirements.txt`
+- Merged PR #105; both alerts (#28, #29) auto-closed on GitHub
+- Discovered two new unrelated high-severity alerts (#30, #31) for lxml < 6.1.0 (XXE in iterparse/ETCompatXMLParser)
+  - Deferred resolution per user request (lxml 4.9→6.1 is major bump with transitive plugin dependency risks)
+
+### Repository Maintenance
+- Pruned three stale merged remote branches:
+  - `chore/dependency-updates-and-cleanup` (merged 2026-04-01)
+  - `fix/security-updates-markdown-pygments` (merged 2026-04-02)
+  - `post/global-mental-health-aging` (merged 2026-04-02)
+- Synchronized local main to latest remote (fast-forward from 9376e64 → 98e96e5)
+
+### Tool Updates (Memory Saved)
+- Documented renamed image processing CLI tools:
+  - `xplat rename --style web` → `iname`
+  - `imgpro` → `ipro`
+  - New subcommand surface differs from old repo docs; noted in memory for future sessions
+
+## Commits Made
+
+| Hash | Message |
+|---|---|
+| 4b9fa1d | feat: add featured image to Waiting for Permission post |
+| 7add492 | fix: apply client edits to Waiting for Permission post |
+| 9376e64 | Merge pull request #104 from ErlenePsyD/post/waiting-for-permission |
+| 6e1c76c | chore: bump pillow to 12.2.0 to patch GHSA-whj4-6x5x-4v2j |
+| 98e96e5 | Merge pull request #105 from ErlenePsyD/chore/bump-pillow |
+
+## Key Files
+
+**Created/Modified:**
+- `erlenepsyd.com/content/blog/waiting-for-permission.md` — published post with client edits
+- `erlenepsyd.com/content/images/wildflowers-ice-plant-bloom.jpg` — featured image (720×540, 186KB)
+- `pyproject.toml` — bumped pillow constraint to >=12.2.0
+- `poetry.lock` — regenerated with Pillow 12.2.0
+- `requirements.txt` — updated to pillow==12.2.0
+
+## Open Items
+
+- **Dependabot alerts #30/#31** (lxml < 6.1.0, XXE) — deferred; revisit when upstream Pelican plugins support lxml 6.x
+- Production site live on erlenepsyd.com with the new post
+
+## Notes
+
+- Client happy with featured image and post structure; all feedback incorporated
+- Security posture improved: Pillow alerts cleared, but lxml alerts remain low-priority due to build-time-only exposure
+- Repo is now clean: only `main` branch exists locally/remotely; all merged feature branches pruned
+- Image processing pipeline now uses `ipro` (replaces `imgpro`) and `iname` (replaces `xplat`) — old repo docs still reference deprecated names; worth updating in a future pass if needed


### PR DESCRIPTION
## Summary

- Adds `devlog/2026-04-22-post-publish-and-security-updates.md` — session summary covering the merge of PR #104 ("Waiting for Permission" post), the merge of PR #105 (Pillow security bump), and the cleanup of stale remote branches.
- Adds `.claude/scheduled_tasks.lock` to `.gitignore` — Claude Code runtime state that shouldn't be tracked.

## Test plan

- [ ] Staging preview builds (devlog files aren't consumed by Pelican, so build should be unaffected)
- [ ] Verify `.gitignore` still behaves as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)