### PR TITLE
chore: enable Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` enabling weekly Dependabot version-update PRs for:
- **pip** (`/`) — covers `requirements.txt` and the Poetry manifests
- **github-actions** (`/`) — keeps CI actions current

## Why

The repo currently has **30 open Dependabot alerts** (15 unique advisories, double-counted across `requirements.txt` and `poetry.lock`), all resolving to two bumps:

| Package | Pinned | Fixed in | Severity |
|---|---|---|---|
| Pillow | 12.2.0 | 12.3.0 | 10 high / 3 medium |
| soupsieve | 2.6 | 2.8.4 | 2 high |

Once this config is on `main`, Dependabot will open the corresponding bump PRs automatically.

## Note

This enables **version** updates. Targeted **security-only** auto-PRs are a separate repo setting (Settings → Code security → "Dependabot security updates") that requires admin access to toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)