### PR TITLE
docs: add photo credit to latest post and fix malformed credit

### DIFF
--- a/erlenepsyd.com/content/blog/aging-script.md
+++ b/erlenepsyd.com/content/blog/aging-script.md
@@ -86,6 +86,4 @@ Consider doing this activity with your life partner, if this suits your relation
 
 ![Dr. R written by hand]({static}/images/dr_r_sm.png)
 
-## Photo Credit
-
-Photo by The Rosowsky Family_
+_Photo by the Rosowsky Family_

--- a/erlenepsyd.com/content/blog/because-i-can.md
+++ b/erlenepsyd.com/content/blog/because-i-can.md
@@ -68,3 +68,5 @@ I can tell myself, _as can you_, that I am flexible, creative, valuable, self-ac
 [Contact me]({filename}/pages/contact.md). I'd love to hear back from you, especially about any creative ways you've put this to use.
 
 ![Dr. R written by hand]({static}/images/dr_r_sm.png)
+
+_Photo by the Rosowsky Family_


### PR DESCRIPTION
## Summary

Client requested the standard photo credit at the end of the latest post, [Because I Can](erlenepsyd.com/content/blog/because-i-can.md).

- **because-i-can.md** — added `_Photo by the Rosowsky Family_` as the last line, after the Dr. R signature image. Matches the convention in `elixir-of-humor.md`. Singular "Photo" since the post has one photograph.
- **aging-script.md** — fixed the same credit, which had a stray trailing underscore (no opening one, so the `_` rendered literally) and an unnecessary `## Photo Credit` heading. Now consistent with the other posts.

## Test plan

- [ ] Check the staging preview: credit renders in italics at the foot of both posts, no stray underscore, no orphan heading in the aging-script table of contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUa91HTyPB3fUAd59gu8ji